### PR TITLE
cargo: bump version-sync dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ png = "0.14"
 
 [dev-dependencies]
 criterion = "0.2"
-version-sync = "0.7"
+version-sync = "0.8"
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
The new version 0.8.0 requires Rust 2018, which this project is already using.